### PR TITLE
[SGP-16183] Parse Locust Stats By Individual Load Test Endpoint and Serve to Users

### DIFF
--- a/locust/stats.py
+++ b/locust/stats.py
@@ -847,6 +847,33 @@ class StatsCSV:
         csv_writer.writerow(self.requests_csv_columns)
         self._requests_data_rows(csv_writer)
 
+    def all_requests_json(self):
+        stats_entries = self.environment.stats.entries
+        all_requests = {}
+        for k, v in stats_entries.items():
+            all_requests[k[0]] = {}
+            runtime_data = all_requests[k[0]]
+            all_reqs_per_s = v.num_reqs_per_sec.copy()
+            all_reqs_timestamps = list(all_reqs_per_s.keys())
+            failures_per_s = v.num_fail_per_sec.copy()
+            runtime_data["method"] = k[1]
+            runtime_data["total_requests"] = v.num_requests
+            runtime_data["total_failures"] = v.num_failures
+            # Everything gets added to num_reqs_per_sec
+            # Things only get added to _num_fail_per_sec if there is a failure
+            # num_reqs_per_sec[secs] - num_fail_per_sec[secs] = num_successes_per_secs
+            runtime_data["num_reqs_per_sec"] = all_reqs_per_s
+            num_successes_per_s = {}
+            for timestamp, count in all_reqs_per_s.items():
+                failure_count = failures_per_s.get(timestamp, 0)
+                num_successes_per_s[timestamp] = count - failure_count
+            runtime_data["num_successes_per_secs"] = num_successes_per_s
+            timestamps_wo_fails = set(all_reqs_timestamps) - set(failures_per_s.keys())
+            for timestamp in timestamps_wo_fails:
+                failures_per_s[timestamp] = 0
+            runtime_data["num_failures_per_sec"] = failures_per_s
+        return all_requests
+
     def _requests_data_rows(self, csv_writer):
         """Write requests csv data row, excluding header."""
         stats = self.environment.stats

--- a/locust/templates/index.html
+++ b/locust/templates/index.html
@@ -184,6 +184,7 @@
                     <a href="./stats/failures/csv">Download failures CSV</a><br>
                     <a href="./exceptions/csv">Download exceptions CSV</a><br>
                     <a href="./stats/report" target="_blank">Download Report</a><br>
+                    <a href="./stats/requests/json">Download individual endpoints requests stats JSON</a><br>
                 </div>
             </div>
             {% if is_distributed %}

--- a/locust/web.py
+++ b/locust/web.py
@@ -198,6 +198,15 @@ class WebUI:
             ] = f"attachment;filename={_download_csv_suggest_file_name(filename_prefix)}"
             return response
 
+        @app.route("/stats/requests/json")
+        @self.auth_required_if_enabled
+        def request_stats_json():
+            data = self.stats_csv_writer.all_requests_json()
+            response = make_response(data)
+            response.headers["Content-type"] = "application/json"
+            response.headers["Content-disposition"] = f"attachment;filename=all_requests_json_{time()}.json"
+            return response
+
         @app.route("/stats/requests/csv")
         @self.auth_required_if_enabled
         def request_stats_csv():


### PR DESCRIPTION
This PR uses the existing stats gathering implemented by Locust and parses them based on each individual endpoint hit in a locust load test (instead of by the summation of all requests, which is built-in to locust) and serves them to locust users.

The goal of this PR is provide a JSON which can then be used by plotly to give Bevy information on the performance of individual API endpoints as the load varies over time. 

Eventually it would be nice to have these stats displayed in a chart during locust runtime, but that would be an extra unit of work. Right now the data is simply served in JSON format and then plotted manually. 

Eventually it would also be nice to have an automated job which posts these stats to datadog or another performance monitoring dashboard. 

NOTE: this is being merged into `bevy/locust`, not into `locustio/locust`