### PR TITLE
[SGP16069] add in select user to webui

### DIFF
--- a/locust/main.py
+++ b/locust/main.py
@@ -176,14 +176,10 @@ def main():
             sys.exit(1)
         else:
             names = set(options.user_classes) & set(user_classes.keys())
-            selected_user_classes = [user_classes[n] for n in names]
-            user_classes = selected_user_classes
-            runner.user_class_test_selection = selected_user_classes
+            user_classes = [user_classes[n] for n in names]
     else:
         # list() call is needed to consume the dict_view object in Python 3
-        all_user_classes = list(user_classes.values())
-        user_classes = all_user_classes
-        runner.user_class_test_selection = all_user_classes
+        user_classes = list(user_classes.values())
 
     if os.name != "nt" and not options.master:
 

--- a/locust/main.py
+++ b/locust/main.py
@@ -161,23 +161,6 @@ def main():
             print("    " + name)
         sys.exit(0)
 
-    if not user_classes:
-        logger.error("No User class found!")
-        sys.exit(1)
-
-    # make sure specified User exists
-    if options.user_classes:
-        missing = set(options.user_classes) - set(user_classes.keys())
-        if missing:
-            logger.error("Unknown User(s): %s\n" % (", ".join(missing)))
-            sys.exit(1)
-        else:
-            names = set(options.user_classes) & set(user_classes.keys())
-            user_classes = [user_classes[n] for n in names]
-    else:
-        # list() call is needed to consume the dict_view object in Python 3
-        user_classes = list(user_classes.values())
-
     if os.name != "nt" and not options.master:
 
         try:
@@ -242,6 +225,27 @@ def main():
             sys.exit(-1)
     else:
         runner = environment.create_local_runner()
+
+    if not user_classes:
+        logger.error("No User class found!")
+        sys.exit(1)
+
+    # make sure specified User exists
+    if options.user_classes:
+        missing = set(options.user_classes) - set(user_classes.keys())
+        if missing:
+            logger.error("Unknown User(s): %s\n" % (", ".join(missing)))
+            sys.exit(1)
+        else:
+            names = set(options.user_classes) & set(user_classes.keys())
+            selected_user_classes = [user_classes[n] for n in names]
+            user_classes = selected_user_classes
+            runner.user_class_test_selection = selected_user_classes
+    else:
+        # list() call is needed to consume the dict_view object in Python 3
+        all_user_classes = list(user_classes.values())
+        user_classes = all_user_classes
+        runner.user_class_test_selection = all_user_classes
 
     # main_greenlet is pointing to runners.greenlet by default, it will point the web greenlet later if in web mode
     main_greenlet = runner.greenlet

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -137,10 +137,12 @@ class Runner:
         Distributes the amount of users for each WebLocust-class according to it's weight
         returns a list "bucket" with the weighted users
         """
+        # Selection, or all tests
+        users = getattr(self, "user_class_test_selection", self.user_classes)
         bucket = []
-        weight_sum = sum([user.weight for user in self.user_class_test_selection])
+        weight_sum = sum([user.weight for user in users])
         residuals = {}
-        for user in self.user_class_test_selection:
+        for user in users:
             if self.environment.host is not None:
                 user.host = self.environment.host
 
@@ -169,6 +171,7 @@ class Runner:
 
     def spawn_users(self, spawn_count, spawn_rate, wait=False):
         bucket = self.weight_users(spawn_count)
+        users = getattr(self, "user_class_test_selection", self.user_classes)
         spawn_count = len(bucket)
         if self.state == STATE_INIT or self.state == STATE_STOPPED:
             self.update_state(STATE_SPAWNING)
@@ -178,7 +181,7 @@ class Runner:
             "Spawning %i users at the rate %g users/s (%i users already running)..."
             % (spawn_count, spawn_rate, existing_count)
         )
-        occurrence_count = dict([(l.__name__, 0) for l in self.user_class_test_selection])
+        occurrence_count = dict([(l.__name__, 0) for l in users])
 
         def spawn():
             sleep_time = 1.0 / spawn_rate

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -138,9 +138,9 @@ class Runner:
         returns a list "bucket" with the weighted users
         """
         bucket = []
-        weight_sum = sum([user.weight for user in self.user_classes])
+        weight_sum = sum([user.weight for user in self.user_class_test_selection])
         residuals = {}
-        for user in self.user_classes:
+        for user in self.user_class_test_selection:
             if self.environment.host is not None:
                 user.host = self.environment.host
 
@@ -178,7 +178,7 @@ class Runner:
             "Spawning %i users at the rate %g users/s (%i users already running)..."
             % (spawn_count, spawn_rate, existing_count)
         )
-        occurrence_count = dict([(l.__name__, 0) for l in self.user_classes])
+        occurrence_count = dict([(l.__name__, 0) for l in self.user_class_test_selection])
 
         def spawn():
             sleep_time = 1.0 / spawn_rate
@@ -198,6 +198,7 @@ class Runner:
                 occurrence_count[user_class.__name__] += 1
                 new_user = user_class(self.environment)
                 new_user.start(self.user_greenlets)
+                logging.info(f"Spawning new {user_class.select_name!r}")
                 if len(self.user_greenlets) % 10 == 0:
                     logger.debug("%i users spawned" % len(self.user_greenlets))
                 if bucket:

--- a/locust/templates/index.html
+++ b/locust/templates/index.html
@@ -66,6 +66,12 @@
                         <input type="text" name="spawn_rate" id="spawn_rate" class="val_disabled" value="-" disabled="disabled" title="Disabled for tests using LoadTestShape class"/><br>
                         <input type="hidden" name="spawn_rate" id="spawn_rate" value="0"/><br>
                     {% else %}
+                        <label for="test_client" class="title">Test Client to Use: </label>
+                        <select id="test_client" name="test_client" class="test-input">
+                            {% for user in user_classes %}
+                            <option value="{{ user.value }}" class="val">{{ user.client_name }}</option>
+                            {% endfor %}
+                        </select><br>
                         <label for="user_count">Number of total users to simulate</label>
                         <input type="text" name="user_count" id="user_count" class="val" value="{{ num_users or "" }}"/><br>
                         <label for="spawn_rate">Spawn rate <span style="color:#8a8a8a;">(users spawned/second)</span></label>

--- a/locust/web.py
+++ b/locust/web.py
@@ -39,7 +39,7 @@ def parse_user_class_dict_from_environment(user_classes):
 
 
 def get_user_class_from_select_value(test_client_value, user_classes_list):
-    return list(filter(lambda x: x["value"] == test_client_value, user_classes_list))[0]["class"]
+    return [list(filter(lambda x: x["value"] == test_client_value, user_classes_list))[0]["class"]]
 
 
 class WebUI:


### PR DESCRIPTION
Note for Reviewer: 

I had one implementation of this in the beginning that was changed in later commits because it broke the unittests. 

For the unittests: the way that locust works normally is that it randomizes your users based on what's live in the locustfile. I had originally changed that in the earlier commits but eventually decided to leave that functionality alone and only add in the ability to select users. This allowed the unittests to keep working in test_runners.py

Example of UI: 

<img width="1104" alt="Screen Shot 2021-04-30 at 4 03 01 PM" src="https://user-images.githubusercontent.com/29210441/116754256-05c3b080-a9ce-11eb-9081-2539ddc786b1.png">
<img width="1160" alt="Screen Shot 2021-04-30 at 4 03 06 PM" src="https://user-images.githubusercontent.com/29210441/116754265-08260a80-a9ce-11eb-851c-59abada00d45.png">

Example of Headless with fake user, one user selected, and base functionality: 

```
(garbagevenv) emily-bevy@Emilys-MacBook-Pro load-testing % locust --headless -u 1 TotallyMadeUpFakeUser
[2021-04-30 16:17:38,956] Emilys-MBP.lan/ERROR/locust.main: Unknown User(s): TotallyMadeUpFakeUser

(garbagevenv) emily-bevy@Emilys-MacBook-Pro load-testing % locust --headless -u 1 BasicRetrievalOfEvents
[2021-04-30 16:17:47,544] Emilys-MBP.lan/INFO/locust.main: No run time limit set, use CTRL+C to interrupt.
[2021-04-30 16:17:47,544] Emilys-MBP.lan/INFO/locust.main: Starting Locust 1.4.3
[2021-04-30 16:17:47,544] Emilys-MBP.lan/INFO/locust.runners: Spawning 1 users at the rate 1 users/s (0 users already running)...
[2021-04-30 16:17:47,545] Emilys-MBP.lan/INFO/root: Spawning new 'Event API GET (Hardcoded Event ID)'
[2021-04-30 16:17:47,545] Emilys-MBP.lan/INFO/locust.runners: All users spawned: BasicRetrievalOfEvents: 1 (1 total running)
 Name                                                          # reqs      # fails  |     Avg     Min     Max  Median  |   req/s failures/s
--------------------------------------------------------------------------------------------------------------------------------------------
--------------------------------------------------------------------------------------------------------------------------------------------
 Aggregated                                                         0     0(0.00%)  |       0       0       0       0  |    0.00    0.00

KeyboardInterrupt
2021-04-30T21:17:49Z
[2021-04-30 16:17:49,485] Emilys-MBP.lan/INFO/locust.main: Running teardowns...
[2021-04-30 16:17:49,485] Emilys-MBP.lan/INFO/locust.main: Shutting down (exit code 0), bye.
[2021-04-30 16:17:49,485] Emilys-MBP.lan/INFO/locust.main: Cleaning up runner...
[2021-04-30 16:17:49,485] Emilys-MBP.lan/INFO/locust.runners: Stopping 1 users
[2021-04-30 16:17:49,487] Emilys-MBP.lan/INFO/locust.runners: 1 Users have been stopped, 0 still running
 Name                                                          # reqs      # fails  |     Avg     Min     Max  Median  |   req/s failures/s
--------------------------------------------------------------------------------------------------------------------------------------------
--------------------------------------------------------------------------------------------------------------------------------------------
 Aggregated                                                         0     0(0.00%)  |       0       0       0       0  |    0.00    0.00

Response time percentiles (approximated)
 Type     Name                                                              50%    66%    75%    80%    90%    95%    98%    99%  99.9% 99.99%   100% # reqs
--------|------------------------------------------------------------|---------|------|------|------|------|------|------|------|------|------|------|------|
--------|------------------------------------------------------------|---------|------|------|------|------|------|------|------|------|------|------|------|

(garbagevenv) emily-bevy@Emilys-MacBook-Pro load-testing % locust --headless -u 1                       
[2021-04-30 16:17:54,351] Emilys-MBP.lan/INFO/locust.main: No run time limit set, use CTRL+C to interrupt.
[2021-04-30 16:17:54,351] Emilys-MBP.lan/INFO/locust.main: Starting Locust 1.4.3
[2021-04-30 16:17:54,351] Emilys-MBP.lan/INFO/locust.runners: Spawning 1 users at the rate 1 users/s (0 users already running)...
[2021-04-30 16:17:54,351] Emilys-MBP.lan/INFO/root: Spawning new 'Event API GET (Hardcoded Event ID)'
[2021-04-30 16:17:54,351] Emilys-MBP.lan/INFO/locust.runners: All users spawned: BasicRetrievalOfEvents: 1, EventGettingUser: 0, LocustGeneratedUserSignsUp: 0 (1 total running)
 Name                                                          # reqs      # fails  |     Avg     Min     Max  Median  |   req/s failures/s
--------------------------------------------------------------------------------------------------------------------------------------------
--------------------------------------------------------------------------------------------------------------------------------------------
 Aggregated                                                         0     0(0.00%)  |       0       0       0       0  |    0.00    0.00

KeyboardInterrupt
2021-04-30T21:17:55Z
[2021-04-30 16:17:55,370] Emilys-MBP.lan/INFO/locust.main: Running teardowns...
[2021-04-30 16:17:55,370] Emilys-MBP.lan/INFO/locust.main: Shutting down (exit code 0), bye.
[2021-04-30 16:17:55,370] Emilys-MBP.lan/INFO/locust.main: Cleaning up runner...
[2021-04-30 16:17:55,370] Emilys-MBP.lan/INFO/locust.runners: Stopping 1 users
[2021-04-30 16:17:55,372] Emilys-MBP.lan/INFO/locust.runners: 1 Users have been stopped, 0 still running
 Name                                                          # reqs      # fails  |     Avg     Min     Max  Median  |   req/s failures/s
--------------------------------------------------------------------------------------------------------------------------------------------
--------------------------------------------------------------------------------------------------------------------------------------------
 Aggregated                                                         0     0(0.00%)  |       0       0       0       0  |    0.00    0.00

Response time percentiles (approximated)
 Type     Name                                                              50%    66%    75%    80%    90%    95%    98%    99%  99.9% 99.99%   100% # reqs
--------|------------------------------------------------------------|---------|------|------|------|------|------|------|------|------|------|------|------|
--------|------------------------------------------------------------|---------|------|------|------|------|------|------|------|------|------|------|------|
```